### PR TITLE
Implement `retain`, `dedup`, `dedup_by`, and `dedup_by_key`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use std::{ptr, mem, slice};
+use std::{fmt, ptr, mem, slice};
 use std::ops::{Deref, DerefMut};
 use alloc::heap;
 use std::marker::PhantomData;
@@ -408,7 +408,11 @@ impl<T> Extend<T> for ThinVec<T> {
     }
 }
 
-
+impl<T: fmt::Debug> fmt::Debug for ThinVec<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
 
 impl<T> Hash for ThinVec<T> where T: Hash {
     fn hash<H>(&self, state: &mut H) where H: Hasher {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -711,7 +711,7 @@ mod tests {
 
     #[test]
     fn test_drop_empty() {
-        let v = ThinVec::<u8>::new();
+        ThinVec::<u8>::new();
     }
 
     #[test]
@@ -721,15 +721,3 @@ mod tests {
         assert_eq!(thin_vec![1,2,3], vec![1,2,3]);
     }
 }
-
-// TODO: steal Vec's tests
-fn main() {
-    let mut vec = ThinVec::new();
-    vec.push(0);
-    vec.push(1);
-
-    println!("{:?}", vec.pop());
-    println!("{:?}", vec.pop());
-    println!("{:?}", vec.pop());
-}
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,10 +290,41 @@ impl<T> ThinVec<T> {
         // TODO
     }
 
-    pub fn retain<F>(&mut self, f: F) where F: FnMut(&T) -> bool { 
-        // TODO
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all elements `e` such that `f(&e)` returns `false`.
+    /// This method operates in place and preserves the order of the retained
+    /// elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[macro_use] extern crate thin_vec;
+    /// # fn main() {
+    /// let mut vec = thin_vec![1, 2, 3, 4];
+    /// vec.retain(|&x| x%2 == 0);
+    /// assert_eq!(&*vec, &[2, 4]);
+    /// # }
+    /// ```
+    pub fn retain<F>(&mut self, mut f: F) where F: FnMut(&T) -> bool {
+        let len = self.len();
+        let mut del = 0;
+        {
+            let v = &mut self[..];
+
+            for i in 0..len {
+                if !f(&v[i]) {
+                    del += 1;
+                } else if del > 0 {
+                    v.swap(i - del, i);
+                }
+            }
+        }
+        if del > 0 {
+            self.truncate(len - del);
+        }
     }
-    
+
     pub fn dedup_by_key<F, K>(&mut self, key: F) where F: FnMut(&mut T) -> K, K: PartialEq<K> {
         // TODO
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,36 @@ pub struct ThinVec<T> {
     boo: PhantomData<T>,
 }
 
+
+/// Creates a `ThinVec` containing the arguments.
+///
+/// ```
+/// #[macro_use] extern crate thin_vec;
+///
+/// fn main() {
+///     let v = thin_vec![1, 2, 3];
+///     assert_eq!(v.len(), 3);
+///     assert_eq!(v[0], 1);
+///     assert_eq!(v[1], 2);
+///     assert_eq!(v[2], 3);
+/// }
+/// ```
+#[macro_export]
+macro_rules! thin_vec {
+    /* TODO
+    ($elem:expr; $n:expr) => (
+        $crate::ThinVec::from_elem($elem, $n)
+    );
+    */
+    ($($x:expr),*) => ({
+        // TODO: Change this to work without cloning the elements.
+        let mut vec = $crate::ThinVec::new();
+        vec.extend_from_slice(&[$($x),*]);
+        vec
+    });
+    ($($x:expr,)*) => (thin_vec![$($x),*])
+}
+
 impl<T> ThinVec<T> {
     pub fn new() -> ThinVec<T> {
         ThinVec {
@@ -338,11 +368,11 @@ impl<T> ThinVec<T> {
 }
 
 impl<T: Clone> ThinVec<T> {
-    fn resize(&mut self, new_len: usize, value: T) {
+    pub fn resize(&mut self, new_len: usize, value: T) {
         // TODO
     }
-    
-    fn extend_from_slice(&mut self, other: &[T]) {
+
+    pub fn extend_from_slice(&mut self, other: &[T]) {
         self.extend(other.iter().cloned())
     }
 }


### PR DESCRIPTION
Implementation copied from the standard library.  The additional changes are to make the doctest work.